### PR TITLE
ruff: apply autofix to cf_box/aggregated_analytics.py

### DIFF
--- a/cf_box/aggregated_analytics.py
+++ b/cf_box/aggregated_analytics.py
@@ -5,11 +5,10 @@ import json
 import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from cf_box.client import CloudflareAPIClient
 from cf_box.logging_config import configure_logging, get_logger
-from cf_box.models import CloudflareAnalyticsGroup
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags cf_box/aggregated_analytics.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `907abe95c4adf878` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"907abe95c4adf878","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->