### PR TITLE
ruff: apply autofix to cf_box/client.py

### DIFF
--- a/cf_box/client.py
+++ b/cf_box/client.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 
 from cf_box.logging_config import get_logger
-from cf_box.models import CloudflareAPIResponse
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags cf_box/client.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `ad60f08e872a4d2e` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"ad60f08e872a4d2e","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->