### PR TITLE
ruff: apply autofix to cf_box/database.py

### DIFF
--- a/cf_box/database.py
+++ b/cf_box/database.py
@@ -1,6 +1,5 @@
 """Database operations using SQLAlchemy."""
 
-import json
 from pathlib import Path
 from typing import Any, Dict, List
 


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags cf_box/database.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `88d83a4c9921e2e8` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"88d83a4c9921e2e8","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->