### PR TITLE
ruff: apply autofix to cloudflare_aggregated_analytics.py

### DIFF
--- a/cloudflare_aggregated_analytics.py
+++ b/cloudflare_aggregated_analytics.py
@@ -1,12 +1,9 @@
-import requests
-import os
 import json
+import os
 import time
-import pandas as pd
 from datetime import datetime, timedelta, timezone
-from reportlab.lib.pagesizes import letter
-from reportlab.pdfgen import canvas
-from typing import Dict, List, Optional
+
+import requests
 
 # Cloudflare API Settings
 CF_API_URL = "https://api.cloudflare.com/client/v4/graphql"


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags cloudflare_aggregated_analytics.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `24014ae8d19a476d` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"24014ae8d19a476d","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->