### PR TITLE
ruff: apply autofix to test_cloudflare_ip_list_manager.py

### DIFF
--- a/test_cloudflare_ip_list_manager.py
+++ b/test_cloudflare_ip_list_manager.py
@@ -1,9 +1,8 @@
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
-from cloudflare_ip_list_manager import (
-    load_config, anonymize_email, anonymize_account_id
-)
+from cloudflare_ip_list_manager import anonymize_account_id, anonymize_email, load_config
+
 
 class TestCloudflareIPListManager(unittest.TestCase):
 


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags test_cloudflare_ip_list_manager.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `ff1a547ac4dd3a6d` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"ff1a547ac4dd3a6d","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->