### PR TITLE
ruff: apply autofix to tests/test_client.py

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,8 @@
 """Tests for async HTTP client."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-import aiohttp
 
 from cf_box.client import CloudflareAPIClient
 


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags tests/test_client.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `e2c57b6d50e3f06d` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"e2c57b6d50e3f06d","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->