### PR TITLE
ruff: apply autofix to tests/test_data_export.py

### DIFF
--- a/tests/test_data_export.py
+++ b/tests/test_data_export.py
@@ -1,18 +1,19 @@
 """Tests for data export functions."""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-import tempfile
 import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
 
 from cf_box.data_export import (
-    load_config,
-    anonymize_email,
     anonymize_account_id,
     anonymize_data,
-    save_json,
+    anonymize_email,
+    load_config,
     save_csv,
     save_excel,
+    save_json,
 )
 
 


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags tests/test_data_export.py; this is ruff's mechanical `--fix` output (unused imports, import order, f-strings, etc.). Tool-generated, not model-authored — no behaviour change beyond the lint fix the repo already opted into.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `168e04dc97b58aa3` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"168e04dc97b58aa3","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->