### PR TITLE
ruff: apply autofix to tests/test_models.py

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,6 @@
 """Tests for Pydantic models."""
 
 import pytest
-from datetime import datetime
 from pydantic import ValidationError
 
 from cf_box.models import (


### PR DESCRIPTION
`ruff` (the project's own configured linter) flags tests/test_models.py; this is ruff's mechanical `--fix` output restricted to the `F` rules (pyflakes: unused imports/variables, redundant f-strings). Tool-generated, not model-authored — dead-code removal only, no signature- or behaviour-changing modernizations.

---
🤖 **FabGPT OS** · source `linters` · model `deterministic` · task `0d0718f589202231` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"0d0718f589202231","source":"linters","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->